### PR TITLE
Delay activation until needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/main",
   "version": "1.8.11",
   "description": "Python packages, variables, methods and functions with their arguments autocompletion powered by Jedi",
-  "activationCommands": {},
+  "activationHooks": ["language-python:grammar-used"],
   "repository": "https://github.com/sadovnychyi/autocomplete-python",
   "license": "GPL",
   "engines": {


### PR DESCRIPTION
Fixes #195 by not activating the package until the user actually opens a
Python file.

This saves me about 100ms of Atom startup time whenever I don't edit Python.

For more details, search for `activationHooks` on
http://flight-manual.atom.io/hacking-atom/sections/package-word-count/