### PR TITLE
Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",
-    "kite-installer": "^0.4.7",
+    "kite-installer": "^0.4.8",
     "selector-kit": "^0.1",
     "space-pen": "^5.1.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Updates `kite-installer` to v0.4.8, which is compatible with older JS engines/versions of atom

Fixes #1 