### PR TITLE
Fix #278 - Unprotected access of @provider.lastSuggestions

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -315,7 +315,7 @@ module.exports =
               @track 'used completion returned by Kite but not Jedi', {
                 kiteHasDocumentation: @hasDocumentation(suggestion)
               }
-          else if suggestion in @provider.lastSuggestions
+          else if @provider.lastSuggestions and  suggestion in @provider.lastSuggestions
             altSuggestion = @hasSameSuggestion(suggestion, @lastKiteSuggestions)
             if altSuggestion?
               @track 'used completion returned by Jedi but also returned by Kite', {

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -353,7 +353,7 @@ module.exports =
               jediHasDocumentation: @hasDocumentation(suggestion)
             }
       else
-        if suggestion in @provider.lastSuggestions
+        if @provider.lastSuggestions and suggestion in @provider.lastSuggestions
           @track 'used completion returned by Jedi', {
             jediHasDocumentation: @hasDocumentation(suggestion)
           }


### PR DESCRIPTION
The check of `@provider.lastSuggestions ` at main.coffee:356 fixes #278 for me. I also found another unprotected access at line 318 that I have changed as well. The traceback in that particular issue leads to line 305

I looked at changing accesses to `@provider.lastSuggestions` to return an empty list rather than, but I'm not really familiar with coffeescript and couldn't figure out how it was defined. That may be a cleaner solution as you wouldn't have to check all accesses to it.