### PR TITLE
Load provider before trying to go to definition

### DIFF
--- a/lib/hyperclick-provider.coffee
+++ b/lib/hyperclick-provider.coffee
@@ -33,5 +33,5 @@ module.exports =
         @log.debug range.start, @_getScopes(editor, range.start)
         @log.debug range.end, @_getScopes(editor, range.end)
       callback = =>
-        @provider.goToDefinition(editor, bufferPosition)
+        @provider.load().goToDefinition(editor, bufferPosition)
       return {range, callback}


### PR DESCRIPTION
This fixes #307 which happens when hyperclick is used before doing any completion.