### PR TITLE
fix variable substitution for interpreter path

### DIFF
--- a/lib/interpreters-lookup.coffee
+++ b/lib/interpreters-lookup.coffee
@@ -56,12 +56,15 @@ module.exports =
   applySubstitutions: (paths) ->
     modPaths = []
     for p in paths
-      for project in atom.project.getPaths()
-        [..., projectName] = project.split(path.sep)
-        p = p.replace(/\$PROJECT_NAME/i, projectName)
-        p = p.replace(/\$PROJECT/i, project)
-        if p not in modPaths
-          modPaths.push p
+      if /\$PROJECT/.test p
+        for project in atom.project.getPaths()
+          [..., projectName] = project.split(path.sep)
+          p = p.replace(/\$PROJECT_NAME/i, projectName)
+          p = p.replace(/\$PROJECT/i, project)
+          if p not in modPaths
+            modPaths.push p
+      else
+        modPaths.push p
     return modPaths
 
   getInterpreter: ->


### PR DESCRIPTION
When the interpreter path does not contain `$PROJECT` or `$PROJECT_NAME`, it should be included even if no project is loaded.
Should fix #259.