### PR TITLE
Don't disable hyperclick at entity.name scope fixes #370

### DIFF
--- a/lib/hyperclick-provider.coffee
+++ b/lib/hyperclick-provider.coffee
@@ -1,7 +1,7 @@
 module.exports =
   priority: 1
   providerName: 'autocomplete-python'
-  disableForSelector: '.source.python .comment, .source.python .string, .source.python .numeric, .source.python .integer, .source.python .decimal, .source.python .punctuation, .source.python .keyword, .source.python .storage, .source.python .variable.parameter, .source.python .entity.name'
+  disableForSelector: '.source.python .comment, .source.python .string, .source.python .numeric, .source.python .integer, .source.python .decimal, .source.python .punctuation, .source.python .keyword, .source.python .storage, .source.python .variable.parameter'
   constructed: false
 
   constructor: ->


### PR DESCRIPTION
In latest Atom + Python grammar, function calls like `foo()` are given an `entity.name` scope, so are excluded from hyperclick suggestions. This removes the scope from `disableForSelector` option.

Appears to fix #370 for me, locally.