### PR TITLE
Use new Kite install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Python packages, variables, methods and functions with their arguments autocompletion in [Atom](http://atom.io) powered by your choice of [Jedi](https://github.com/davidhalter/jedi) or [Kite](https://kite.com).
 
-_Please note that this package is sponsored by Kite and that the Kite code engine is cloud-powered.  Type inference on your code is done on Kite's servers._  More info is provided during the install screens of autocomplete-python.  __Please read Kite's [privacy policy](https://kite.com/privacy) and [FAQ](http://help.kite.com/category/30-security-privacy) carefully if you have chosen Kite as your completions engine.__
+_Please note that this package is sponsored by Kite and that the Kite code engine is cloud-powered.  Type inference on your code is done on Kite's servers._  More info is provided during the install screens of autocomplete-python.  __Please read Kite's [privacy policy](https://kite.com/privacy) and [FAQ](https://help.kite.com/category/41-security-privacy) carefully if you have chosen Kite as your completions engine.__
 
 See [releases](https://github.com/sadovnychyi/autocomplete-python/releases) for release notes.
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -168,7 +168,7 @@ module.exports =
     pluginCfg =
       name: 'autocomplete-python'
 
-    Metrics.Tracker.source = 'acp'
+    Metrics.Tracker.source = 'autocomplete-python'
     Metrics.enabled = atom.config.get('core.telemetryConsent') is 'limited'
 
     atom.packages.onDidActivatePackage (pkg) =>

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -168,13 +168,12 @@ module.exports =
     pluginCfg =
       name: 'autocomplete-python'
 
-    Metrics.Tracker.name = "atom acp"
+    Metrics.Tracker.source = 'acp'
     Metrics.enabled = atom.config.get('core.telemetryConsent') is 'limited'
 
     atom.packages.onDidActivatePackage (pkg) =>
       if pkg.name is 'kite'
         @patchKiteCompletions(pkg)
-        Metrics.Tracker.name = "atom kite+acp"
 
     checkKiteInstallation = () =>
       return unless atom.config.get 'autocomplete-python.useKite'
@@ -185,7 +184,7 @@ module.exports =
           path: atom.project.getPaths()[0] || os.homedir(),
         }, {
           failureStep: 'termination',
-          title: 'Kite Install',
+          title: 'Choose your autocomplete-python engine',
         })
 
         initialClient = AccountManager.client

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",
-    "kite-installer": "^0.23.2",
+    "kite-installer": "^2.0.4",
     "selector-kit": "^0.1",
     "space-pen": "^5.1.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
This PR updates the `kite-installer` dependency to the latest version. It includes the following changes:

1. More robust and tested API to handle Kite state changes
2. Updates to copy - specifically, it makes clear on the first step that Jedi will be installed no matter which engine the user chooses
