### PR TITLE
Fix install for non-admin users

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -210,6 +210,17 @@ module.exports =
           atom.config.set('autocomplete-python.useKite', installed)
         )
 
+        installer.on('not-admin-shown', () ->
+          # Show installation again if user restarts as admin. There is a
+          # separate user option to explicitly not show this again.
+          installed = true
+        )
+
+        installer.on('not-admin-dismissed', () ->
+          installed = false
+          atom.config.set('autocomplete-python.useKite', installed)
+        )
+
         installer.start()
       , (err) =>
         if typeof err != 'undefined' and err.type == 'denied'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",
-    "kite-installer": "^2.0.5",
+    "kite-installer": "^2.0.7",
     "selector-kit": "^0.1",
     "space-pen": "^5.1.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Previously an error would occur if a non-admin user attempted to install Kite. This PR incorporates a change from `kite-installer` that prevents this error from occurring.