### PR TITLE
Exit the completion process on EOF

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -326,8 +326,6 @@ class JediCompletion(object):
     def _process_request(self, request):
         """Accept serialized request from Atom and write response.
         """
-        if not request:
-          return
         request = self._deserialize(request)
 
         self._set_request_config(request.get('config', {}))
@@ -371,7 +369,11 @@ class JediCompletion(object):
         while True:
             try:
                 sys.stdout, sys.stderr = self.devnull, self.devnull
-                self._process_request(self._input.readline())
+                request = self._input.readline()
+                if not request:
+                    return
+
+                self._process_request(request)
             except Exception:
                 sys.stderr = self.stderr
                 sys.stderr.write(traceback.format_exc() + '\n')


### PR DESCRIPTION
Coming from https://github.com/brennv/autocomplete-python-jedi/commit/44e24b1ff710427b2da091ce5f7a0a7e36782dab

"
Exit the completion process on EOF

The real problem is that `BufferedProcess.kill` is *asynchronous* on
Windows and Atom exits before it gets a chance to complete. So the
process is left alive, and it ignores EOF and just keeps trying to read
in an infinite loop.
"
Fixes https://github.com/autocomplete-python/autocomplete-python/issues/310
And probably https://github.com/autocomplete-python/autocomplete-python/issues/301