### PR TITLE
Stop auto-inserting completions

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -321,6 +321,9 @@ module.exports =
   setSnippetsManager: (@snippetsManager) ->
 
   _completeArguments: (editor, bufferPosition, force) ->
+    # Skip this if Kite is active
+    return if atom.packages.isPackageActive('kite')
+
     useSnippets = atom.config.get('autocomplete-python.useSnippets')
     if not force and useSnippets == 'none'
       atom.commands.dispatch(document.querySelector('atom-text-editor'),


### PR DESCRIPTION
This PR fixes the situation where both Kite and autocomplete-python are active and the "Automatically Confirm Single Suggestion" setting from autocomplete-plus is enabled. Previously, this combination would result in snippets being inserted automatically into the buffer without user interaction. This PR prevents that by letting autocomplete-python defer to Kite when completions are triggered.