### PR TITLE
Suppress completions if Kite is enabled

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -367,6 +367,7 @@ module.exports =
     return candidates
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
+    return if atom.packages.isPackageActive('kite')
     @load()
     if not @triggerCompletionRegex.test(prefix)
       return @lastSuggestions = []


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/9885

If Kite's enabled, don't fetch suggestions using Jedi. If Kite is disabled, fall back to Jedi.